### PR TITLE
Add Filtering to the ExampleAddon & Make Logging only in Demo and Studio

### DIFF
--- a/Loader/Addons/ExampleAddon.luau
+++ b/Loader/Addons/ExampleAddon.luau
@@ -1,6 +1,6 @@
 -- addons not containing in "Client" or "Server" will run in both contexts (shared)
 return function(_K)
-	if game.PlaceId == 2569622788 or game:GetService("RunService"):IsStudio() then -- ONLY FOR DEMO PLACE
+	if game.PlaceId == 2569622788 or _K.IsStudio then -- ONLY FOR DEMO PLACE
 		_K.log(`Hello World from ExampleAddon!`, "INFO")
 	end
 
@@ -59,7 +59,7 @@ return function(_K)
 
 		env = function(_K)
 			-- This will only run once on each server while in studio or in the demo place
-			if game.PlaceId == 2569622788 or game:GetService("RunService"):IsStudio() then
+			if game.PlaceId == 2569622788 or _K.IsStudio then
 				_K.log(`Hello World from ExampleAddon customcommand env!`, "INFO")
 			end
 
@@ -71,7 +71,7 @@ return function(_K)
 
 		envClient = function(_K)
 			-- This will only run once on each client while in studio or in the demo place
-			if game.PlaceId == 2569622788 or game:GetService("RunService"):IsStudio() then
+			if game.PlaceId == 2569622788 or _K.IsStudio then
 				_K.log(`Hello World from ExampleAddon customcommand envClient!`, "INFO")
 			end
 

--- a/Loader/Addons/ExampleAddon.luau
+++ b/Loader/Addons/ExampleAddon.luau
@@ -1,6 +1,8 @@
 -- addons not containing in "Client" or "Server" will run in both contexts (shared)
 return function(_K)
-	_K.log(`Hello World from ExampleAddon!`, "INFO")
+	if game.PlaceId == 2569622788 or game:GetService("RunService"):IsStudio() then -- ONLY FOR DEMO PLACE
+		_K.log(`Hello World from ExampleAddon!`, "INFO")
+	end
 
 	_K.Registry.registerCommand(_K, {
 		name = "customcommand",
@@ -56,8 +58,10 @@ return function(_K)
 		-- Command environment
 
 		env = function(_K)
-			-- This will only run once on each server
-			_K.log(`Hello World from ExampleAddon customcommand env!`, "INFO")
+			-- This will only run once on each server while in studio or in the demo place
+			if game.PlaceId == 2569622788 or game:GetService("RunService"):IsStudio() then
+				_K.log(`Hello World from ExampleAddon customcommand env!`, "INFO")
+			end
 
 			-- This table is passed to the `run` function as `context.env`
 			return {
@@ -66,8 +70,10 @@ return function(_K)
 		end,
 
 		envClient = function(_K)
-			-- This will only run once on each client
-			_K.log(`Hello World from ExampleAddon customcommand envClient!`, "INFO")
+			-- This will only run once on each client while in studio or in the demo place
+			if game.PlaceId == 2569622788 or game:GetService("RunService"):IsStudio() then
+				_K.log(`Hello World from ExampleAddon customcommand envClient!`, "INFO")
+			end
 
 			-- This table is passed to the `runClient` function as `context.env`
 			return {
@@ -93,6 +99,11 @@ return function(_K)
 
 		-- Function that runs on the server when the command is called
 		run = function(context, message: string?)
+			-- Filtering the message before-hand with the String Utility API
+			-- You can see other Util API on the documentation: https://docs.kohl.gg/api/Util
+			
+			message = _K.Util.String.filterForBroadcast(message, context.from) or nil
+
 			-- Create a simple Roblox message object
 			local messageInstance = Instance.new("Message", workspace)
 

--- a/MainModule/Util/String.luau
+++ b/MainModule/Util/String.luau
@@ -47,6 +47,7 @@ function String.trim(s: string): string
 	return if string.find(s, "^%s*$") then "" else (string.match(s, "^%s*(.*%S)") or "")
 end
 
+--- Filters a message with [TextService.FilterStringAsync] for broadcast messages
 function String.filterForBroadcast(message: string, fromUserId: number, filterContext: Enum.TextFilterContext?): string
 	local ok, result = Retry(function()
 		return TextService:FilterStringAsync(message, fromUserId, filterContext or Enum.TextFilterContext.PublicChat)

--- a/MainModule/init.luau
+++ b/MainModule/init.luau
@@ -33,6 +33,10 @@ export type Hook = "log" | "preCommand" | "postCommand"
 	.Util Util
 	.UI UI
 
+	.IsClient boolean
+	.IsServer boolean
+	.IsStudio boolean
+
 	.client { [any]: any }?
 	.pinnedAnnouncement {}?
 	.playerPrefix { [Player]: string }


### PR DESCRIPTION
Previously, the command registered by the ExampleAddon.luau makes the server to create an [Message Instance](https://create.roblox.com/docs/reference/engine/classes/Message) on the workspace, showing it to all players in-game with a custom text if an argument was added on it.

```lua
-- Function that runs on the server when the command is called
run = function(context, message: string?)
	-- Create a simple Roblox message object
	local messageInstance = Instance.new("Message", workspace)
  
	-- Since our message is optional we need to check nil for a default value
	messageInstance.Text = if message == nil then "Default message" else message

	-- Destroy the message after 5 seconds
	task.delay(5, messageInstance.Destroy, messageInstance)

	-- Number of times the command has been used on this server
	context.env.countServer += 1
	print("Custom command ran on server!", message, context.env.countServer)
end
```

> The argument was not filtered previously, causing any person in-game with moderator permissions being able to create unfiltered messages on the server, something which the Roblox Terms Of Service is against of, issue was fixed by doing usage of `_K.Util.String.filterForBroadcast`

I've also, decided to reduce clutter on the logs for admins, by making it so the example `_K.Log` is only ran on the demo place and on studio, this way making the logs not that piled up.