### PR TITLE
Validate Optional Arguments If They Are On Use & Fix Control Command

### DIFF
--- a/src/DefaultCommands/Fun.luau
+++ b/src/DefaultCommands/Fun.luau
@@ -300,7 +300,7 @@ return {
 						return
 					end
 					for _, descendant in target.Character:GetDescendants() do
-						if descendant:IsA("BasePart") then
+						if descendant:IsA("BasePart") and descendant:CanSetNetworkOwnership() then
 							descendant:SetNetworkOwner(controller)
 						end
 					end
@@ -335,12 +335,16 @@ return {
 					local original = controller:FindFirstChild("_KControlOriginal")
 					if original then
 						local character = original.Value
-						for _, descendant in character:GetDescendants() do
-							if descendant:IsA("BasePart") then
-								descendant:SetNetworkOwner(controller)
+						
+						if character then
+							for _, descendant in character:GetDescendants() do
+								if descendant:IsA("BasePart") and descendant:CanSetNetworkOwnership() then
+									descendant:SetNetworkOwner(controller)
+								end
 							end
+							
+							controller.Character = character
 						end
-						controller.Character = character
 					end
 				end,
 				release = function(controller)
@@ -360,17 +364,19 @@ return {
 							end
 						end
 
-						for _, descendant in character:GetDescendants() do
-							if descendant:IsA("BasePart") then
-								descendant:SetNetworkOwner(networkOwner)
+						if character and networkOwner then
+							for _, descendant in character:GetDescendants() do
+								if descendant:IsA("BasePart") and descendant:CanSetNetworkOwnership() then
+									descendant:SetNetworkOwner(networkOwner)
+								end
 							end
-						end
 
-						local oldParent = character.Parent
-						character.Parent = nil
-						controller.Character = nil
-						character.Parent = oldParent
-						originalController.Character = character
+							local oldParent = character.Parent
+							character.Parent = nil
+							controller.Character = nil
+							character.Parent = oldParent
+							originalController.Character = character
+						end
 					end
 				end,
 			}
@@ -378,7 +384,9 @@ return {
 
 		runClient = function(context, player)
 			if player and context.alias ~= "uncontrol" and context.alias ~= "release" then
-				workspace.CurrentCamera.CameraSubject = player.Character
+				if player.Character then
+					workspace.CurrentCamera.CameraSubject = player.Character
+				end
 			else -- release control
 				local original = context.fromPlayer:FindFirstChild("_KControlOriginal")
 				if original then

--- a/src/Process/Argument.luau
+++ b/src/Process/Argument.luau
@@ -64,9 +64,13 @@ function Argument:transform()
 end
 
 function Argument:validate()
-	--if self.validated or self.definition.optional then
-	--	return true
-	--end
+	if self.validated then
+		return true
+	end
+
+	if self.definition.optional and string.len(self.rawArg) == 0 then
+		return true
+	end
 
 	if self.command.invalidArg then
 		return false, self.command.invalidMessage

--- a/src/Process/Argument.luau
+++ b/src/Process/Argument.luau
@@ -64,9 +64,9 @@ function Argument:transform()
 end
 
 function Argument:validate()
-	if self.validated or self.definition.optional then
-		return true
-	end
+	--if self.validated or self.definition.optional then
+	--	return true
+	--end
 
 	if self.command.invalidArg then
 		return false, self.command.invalidMessage


### PR DESCRIPTION
## Validation of Optional Arguments
Validates optional arguments by verifying if there is no input on the argument being passed thru, fixes #176 where it would cause the :parse() to fail and make the autocomplete error, making it stay idle.

Previously:
```lua
function Argument:validate()
	if self.validated or self.definition.optional then
		return true
	end

	if self.command.invalidArg then
		return false, self.command.invalidMessage
	end
...
```

After Commit:
```lua
function Argument:validate()
	if self.validated then
		return true
	end

	if self.definition.optional and string.len(self.rawArg) == 0 then
		return true
	end
...
```

## Fix of the Control command
Fixed the control command `uncontrol` or `release` when used after the player leaves the game, making Kohl error by trying either set ownership to parts that are not in workspace or indexing with nil.