### PR TITLE
Added aliases on "clearlogs"

### DIFF
--- a/src/DefaultCommands/Creator.luau
+++ b/src/DefaultCommands/Creator.luau
@@ -3,6 +3,7 @@
 return {
 	{
 		name = "clearlogs",
+                aliases = { "clrlogs" },
 		description = "Removes all Kohl's Admin server logs.",
 		args = {},
 		envClient = function(_K)


### PR DESCRIPTION
Added the "clrlogs" aliases to the "clearlogs" command to make it more convenient for users.  This provides a shorter alternative for executing the same command.