### PR TITLE
Fix an issue with donating in a game with third party purchases disabled

### DIFF
--- a/src/Client/About.luau
+++ b/src/Client/About.luau
@@ -94,12 +94,12 @@ function About.new(_K)
 
 	local function promptThirdPartyGamePassDialog(passId)
 		UI.Scope.lastAttemptedPurchase = passId
+		purchaseDialog.Text:set(thirdPartyText)
+		purchaseLink.Text = "https://roblox.com/game-pass/" .. passId
 		if UI.Scope.AllowThirdPartySales then
 			purchaseDialog.Visible:set(false)
 			_K.Util.Services.MarketplaceService:PromptGamePassPurchase(_K.UI.LocalPlayer, passId)
 		else
-			purchaseDialog.Text:set(thirdPartyText)
-			purchaseLink.Text = "https://roblox.com/game-pass/" .. passId
 			purchaseDialog.Visible:set(true)
 		end
 	end
@@ -144,7 +144,7 @@ function About.new(_K)
 			con:Disconnect()
 			UI.Scope.AllowThirdPartySales = false
 			if UI.Scope.lastAttemptedPurchase then
-				purchaseDialog._instance.Visible = true
+				purchaseDialog.Visible:set(true)
 			end
 		end
 	end)

--- a/src/Client/About.luau
+++ b/src/Client/About.luau
@@ -94,12 +94,12 @@ function About.new(_K)
 
 	local function promptThirdPartyGamePassDialog(passId)
 		UI.Scope.lastAttemptedPurchase = passId
-		purchaseDialog.Text:set(thirdPartyText)
-		purchaseLink.Text = "https://roblox.com/game-pass/" .. passId
 		if UI.Scope.AllowThirdPartySales then
 			purchaseDialog.Visible:set(false)
 			_K.Util.Services.MarketplaceService:PromptGamePassPurchase(_K.UI.LocalPlayer, passId)
 		else
+			purchaseDialog.Text:set(thirdPartyText)
+			purchaseLink.Text = "https://roblox.com/game-pass/" .. passId
 			purchaseDialog.Visible:set(true)
 		end
 	end


### PR DESCRIPTION
discord display name is watchr
this pull request fixes the issue in games with third party purchases disabled, where if you click a button to donate robux in the `;donate` command window, it will show a dialog with a link to the 10 robux donation and will not allow you to close it until you select another donation