### PR TITLE
Optimize Retry for Asset Ownership Check

### DIFF
--- a/src/Client/GetKA.luau
+++ b/src/Client/GetKA.luau
@@ -5,7 +5,7 @@ task.defer(function()
 	local adminModelId = 172732271
 	local ok, owned = _K.Util.Retry(function()
 		return _K.Util.Services.MarketplaceService:PlayerOwnsAsset(_K.UI.LocalPlayer, adminModelId)
-	end, 5, 1, 2)
+	end, 3, 0.5, 1.5)
 
 	if not ok or owned then
 		return


### PR DESCRIPTION
Switched from Retry(5, 1, 2) to Retry(3, 0.5, 1.5) for the MarketplaceService:PlayerOwnsAsset call. This check is non-critical and only affects whether a UI button is shown. Reducing retries improves UX by avoiding unnecessary delays and makes the function more responsive.