### PR TITLE
feat: chat nametag color commands

### DIFF
--- a/src/Client/init.client.luau
+++ b/src/Client/init.client.luau
@@ -174,10 +174,29 @@ local function Chatted(message: string)
 	end
 end
 
+local function windowAdded(message: TextChatMessage)
+	local Players = _K.Service.Players
+	local chatWindowConfiguration = _K.Service.TextChat.ChatWindowConfiguration
+
+	local properties = chatWindowConfiguration:DeriveNewMessageProperties()
+
+	if message.TextSource then
+		local color = Players:GetPlayerByUserId(message.TextSource.UserId):GetAttribute("_Kchatcolor")
+		if color then
+			properties.PrefixTextProperties = chatWindowConfiguration:DeriveNewMessageProperties()
+			properties.PrefixTextProperties.TextColor3 = color
+		end
+	end
+
+	return properties
+end
+
 if _K.Service.TextChat.ChatVersion == Enum.ChatVersion.TextChatService then
 	_K.Service.TextChat.SendingMessage:Connect(function(textChatMessage: TextChatMessage)
 		Chatted(_K.Util.String.unescapeRichText(textChatMessage.Text))
 	end)
+
+	_K.Service.TextChat.OnChatWindowAdded = windowAdded -- this runs on every chat message, outgoing or inbound
 end
 
 _K.Remote.Command.OnClientEvent:Connect(Chatted)

--- a/src/DefaultCommands/SuperAdmin.luau
+++ b/src/DefaultCommands/SuperAdmin.luau
@@ -219,4 +219,45 @@ return {
 			context._K.Service.Messaging:PublishAsync("KA_GlobalCommand", { context.from, commandString })
 		end,
 	},
+	{
+		name = "chatcolor",
+		aliases = { "ccolor" },
+		description = "Changes a user's name color in chat.",
+		args = {
+			{
+				type = "players",
+				name = "Player(s)",
+				description = "The player(s) to change the chat color of.",
+			},
+			{
+				type = "color",
+				name = "Color",
+				description = "Color to change the user's nametag to.",
+			},
+		},
+
+		run = function(context, players: { Player }, color: Color3)
+			for _, player in players do
+				player:SetAttribute("_Kchatcolor", color)
+			end
+		end,
+	},
+	{
+		name = "unchatcolor",
+		aliases = { "unccolor" },
+		description = "Removes a user's name color in chat.",
+		args = {
+			{
+				type = "players",
+				name = "Player(s)",
+				description = "The player(s) to change the chat color of.",
+			},
+		},
+
+		run = function(context, players: { Player }, color: Color3)
+			for _, player in players do
+				player:SetAttribute("_Kchatcolor", nil)
+			end
+		end,
+	},
 }


### PR DESCRIPTION
implements #313.

Adds :chatcolor and :unchatcolor which override a user's chat color. This is done via an attribute put onto the player which is read by clients for each message.