### PR TITLE
chore: fix menu box bounds check

### DIFF
--- a/src/Client/UI/DefaultClasses/Menu.luau
+++ b/src/Client/UI/DefaultClasses/Menu.luau
@@ -117,13 +117,13 @@ function Menu.new(definition)
 					0,
 					UI.peek(UI.TopbarInset).Height
 				))
-
 			if
-				(mouse.X < boundsTL.X and mouse.Y < boundsTL.Y) --box bounds check, ty random dev forum post
-				and (mouse.X > boundsBR.X and mouse.Y > boundsBR.Y)
+				(mouse.X > boundsTL.X and mouse.Y > boundsTL.Y) --box bounds check, ty random dev forum post
+				and (mouse.X < boundsBR.X and mouse.Y < boundsBR.Y)
 			then
-				UI.deactivateState(new.Visible, "floating")
+				return --mouse is within bounds
 			end
+			UI.deactivateState(new.Visible, "floating")
 		end)
 	end
 


### PR DESCRIPTION
fixes menu box bounds check that closes menus when clicking outside of their bounds