### PR TITLE
feat: Add createteam, editteam, removeteam, clearteams commands

### DIFF
--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2442,7 +2442,6 @@ return {
 					Text = `<b>Edited team:</b> <font color="#{oldColor:ToHex()}">{oldName}</font> to <font color="#{color:ToHex()}">{name}</font>`,
 				})
 			else
-				-- notify the player
 				context._K.Remote.Notify:FireClient(context.fromPlayer, {
 					From = "_K",
 					Text = `<b>Failed to edit team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,
@@ -2468,13 +2467,11 @@ return {
 		run = function(context, team)
 			if team and context._K.Service.Teams:FindFirstChild(team.Name) then
 				team:Destroy()
-				-- notify the player
 				context._K.Remote.Notify:FireClient(context.fromPlayer, {
 					From = "_K",
 					Text = `<b>Removed team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,
 				})
 			else
-				-- notify the player
 				context._K.Remote.Notify:FireClient(context.fromPlayer, {
 					From = "_K",
 					Text = `<b>Failed to remove team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,

--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2375,7 +2375,7 @@ return {
 		run = function(context, name, color)
 			local team = Instance.new("Team")
 			if not color then
-				color = BrickColor.random()
+				color = BrickColor.random().Color
 			end
 			team.Name = name
 			team.TeamColor = BrickColor.new(color)

--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2366,13 +2366,16 @@ return {
 				description = "The name of the new team.",
 			},
 			{
-				type = "color",
+				type = "color?",
 				name = "Color",
 				description = "The color of the new team.",
 			},
 		},
 		run = function(context, name, color)
 			local team = Instance.new("Team")
+			if not color then
+				color = BrickColor.random()
+			end
 			team.Name = name
 			team.TeamColor = BrickColor.new(color)
 			team.AutoAssignable = true

--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2395,6 +2395,62 @@ return {
 		end,
 	},
 	{
+		name = "editteam",
+		aliases = { "eteam" },
+		description = "Edits a team with the given name and color.",
+		credit = {
+			"Realistic @iiRealistic_Dev",
+			"Kohl @Scripth",
+		},
+		args = {
+			{
+				type = "team",
+				name = "Team",
+				description = "The team to edit.",
+			},
+			{
+				type = "string",
+				name = "Name",
+				description = "The new name of the team.",
+			},
+			{
+				type = "color",
+				name = "Color",
+				optional = true,
+				description = "The new color of the team.",
+			},
+			{
+				type = "boolean",
+				name = "AutoAssignable",
+				optional = true,
+				description = "If the team is AutoAssignable.",
+			},
+		},
+
+		run = function(context, team, name, color, autoAssignable)
+			if team and context._K.Service.Teams:FindFirstChild(team.Name) then
+				local oldColor, oldName = team.TeamColor.Color, team.Name
+				if not color then
+					color = BrickColor.random().Color
+				end
+				team.Name = name
+				team.TeamColor = BrickColor.new(color)
+				team.AutoAssignable = autoAssignable
+
+				context._K.Remote.Notify:FireClient(context.fromPlayer, {
+					From = "_K",
+					Text = `<b>Edited team:</b> <font color="#{oldColor:ToHex()}">{oldName}</font> to <font color="#{color:ToHex()}">{name}</font>`,
+				})
+			else
+				-- notify the player
+				context._K.Remote.Notify:FireClient(context.fromPlayer, {
+					From = "_K",
+					Text = `<b>Failed to edit team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,
+				})
+			end
+		end,
+	},
+	{
 		name = "removeteam",
 		aliases = { "delteam", "deleteteam" },
 		description = "Removes a team with the given name.",

--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2371,15 +2371,21 @@ return {
 				optional = true,
 				description = "The color of the new team.",
 			},
+			{
+				type = "boolean",
+				name = "AutoAssignable",
+				optional = true,
+				description = "If the new team is AutoAssignable.",
+			},
 		},
-		run = function(context, name, color)
+		run = function(context, name, color, autoAssignable)
 			local team = Instance.new("Team")
 			if not color then
 				color = BrickColor.random().Color
 			end
 			team.Name = name
 			team.TeamColor = BrickColor.new(color)
-			team.AutoAssignable = true
+			team.AutoAssignable = autoAssignable
 			team.Parent = context._K.Service.Teams
 
 			context._K.Remote.Notify:FireClient(context.fromPlayer, {

--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2366,8 +2366,9 @@ return {
 				description = "The name of the new team.",
 			},
 			{
-				type = "color?",
+				type = "color",
 				name = "Color",
+				optional = true,
 				description = "The color of the new team.",
 			},
 		},
@@ -2411,8 +2412,7 @@ return {
 					Text = `<b>Removed team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,
 				})
 			else
-				context._K.log("Could not delete team: " .. team.Name, "ERROR")
-				-- noyify the player
+				-- notify the player
 				context._K.Remote.Notify:FireClient(context.fromPlayer, {
 					From = "_K",
 					Text = `<b>Failed to remove team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,

--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2352,4 +2352,88 @@ return {
 			end
 		end,
 	},
+	{
+		name = "createteam",
+		aliases = { "cteam", "newteam" },
+		description = "Creates a new team with the given name and color.",
+		credit = {
+			"Realistic @iiRealistic_Dev",
+		},
+		args = {
+			{
+				type = "string",
+				name = "Name",
+				description = "The name of the new team.",
+			},
+			{
+				type = "color",
+				name = "Color",
+				description = "The color of the new team.",
+			},
+		},
+		run = function(context, name, color)
+			local team = Instance.new("Team")
+			team.Name = name
+			team.TeamColor = BrickColor.new(color)
+			team.AutoAssignable = true
+			team.Parent = context._K.Service.Teams
+
+			context._K.Remote.Notify:FireClient(context.fromPlayer, {
+				From = "_K",
+				Text = `<b>Created team:</b> <font color="#{color:ToHex()}">{name}</font>`,
+			})
+		end,
+	},
+	{
+		name = "removeteam",
+		aliases = { "delteam", "deleteteam" },
+		description = "Removes a team with the given name.",
+		credit = {
+			"Realistic @iiRealistic_Dev",
+		},
+		args = {
+			{
+				type = "team",
+				name = "Team",
+				description = "The team to remove.",
+			},
+		},
+
+		run = function(context, team)
+			if team and context._K.Service.Teams:FindFirstChild(team.Name) then
+				team:Destroy()
+				-- notify the player
+				context._K.Remote.Notify:FireClient(context.fromPlayer, {
+					From = "_K",
+					Text = `<b>Removed team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,
+				})
+			else
+				context._K.log("Could not delete team: " .. team.Name, "ERROR")
+				-- noyify the player
+				context._K.Remote.Notify:FireClient(context.fromPlayer, {
+					From = "_K",
+					Text = `<b>Failed to remove team:</b> <font color="#{team.TeamColor.Color:ToHex()}">{team.Name}</font>`,
+				})
+			end
+		end,
+	},
+	{
+		name = "clearteams",
+		aliases = { "ctm", "cleartm" },
+		description = "Clears all teams.",
+		credit = {
+			"Realistic @iiRealistic_Dev",
+		},
+		run = function(context)
+			for _, team in context._K.Service.Teams:GetTeams() do
+				if team.Name ~= "Neutral" then
+					team:Destroy()
+				end
+			end
+			context._K.Remote.Notify:FireClient(context.fromPlayer, {
+				From = "_K",
+				Text = "<b>Cleared all teams.</b>",
+			})
+		end,
+	},
 }

--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2435,9 +2435,7 @@ return {
 		},
 		run = function(context)
 			for _, team in context._K.Service.Teams:GetTeams() do
-				if team.Name ~= "Neutral" then
-					team:Destroy()
-				end
+				team:Destroy()
 			end
 			context._K.Remote.Notify:FireClient(context.fromPlayer, {
 				From = "_K",


### PR DESCRIPTION
-Adds ;createteam along with ;cteam and ;newteam aliases. Usage of ;createteam <name> <color?>
-Adds ;removeteam along with ;delteam and ;deleteteam aliases - ;rteam could not be added because of ;randomizeteams - -;rmteams is another potential alias but not one I added. Usage is ;removeteam <team>
-Adds ;clearteams with alias ;ctm and ;cleartm. Clears all teams,

When a colour is not provided for ;createteam, it provides a random colour to avoid tons of grey/off-white teams. This may need to be altered if general people prefer not providing a colour to give a singular default instead.

Each command sends confirmation to the player - with createteam and removeteam saying "Created/Removed team: TEAM_NAME" - where team name will also be the selected colour. clearteams just sends a bold message saying Cleared all teams.

Currently, all above commands are, by default, available under the Moderation group. I'm unsure about ;clearteams and whether that should be admin, but since the same stuff can be done much more slowly with ;removeteam I doubt it.

** This PR should not have the same issues as the prior one.