### PR TITLE
(feat) Add ;collide command

### DIFF
--- a/src/DefaultCommands/Moderation/init.luau
+++ b/src/DefaultCommands/Moderation/init.luau
@@ -2516,7 +2516,15 @@ return {
 				setCollision = function(character: Model, collide: boolean)
 					for _, descendant in character:GetDescendants() do
 						if descendant:IsA("BasePart") then
-							descendant.CollisionGroup = if collide then "Default" else COLLISION_GROUP
+							if not descendant:GetAttribute("_KCollisionGroup") then
+								descendant:SetAttribute("_KCollisionGroup", descendant.CollisionGroup)
+							end
+							descendant.CollisionGroup = if collide
+								then descendant:GetAttribute("_KCollisionGroup")
+								else COLLISION_GROUP
+							if collide then
+								descendant:SetAttribute("_KCollisionGroup", nil)
+							end
 						end
 					end
 				end,


### PR DESCRIPTION
Adds ;collide (alias ;collision and ;collisions) command. 

This command makes use of Collisions Groups to prevent players colliding. The way this works is setting their collision group - so if they are removed from the team or anything, you will need to run `;collide user true` again to disable the effects. This seemed the most reasonable way to have it in one command. 