### PR TITLE
chore: Improve time command

### DIFF
--- a/src/DefaultCommands/Environment.luau
+++ b/src/DefaultCommands/Environment.luau
@@ -288,59 +288,35 @@ return {
 	{
 		name = "time",
 		aliases = { "clocktime" },
-		description = "Changes the value of Lighting.ClockTime. Optionally supports minutes and smooth tweening.",
+		description = "Changes the value of Lighting.ClockTime.",
 		args = {
 			{
 				type = "string",
 				name = "Time",
-				description = "The time of the day to set to. Can be HH, HH:MM or HH:MM:SS.",
-			},
-			{
-				type = "boolean",
-				name = "Smooth",
-				description = "If true, the time change will be animated smoothly over a short period of time.",
-				optional = true,
+				description = "The time of day, can be HH, HH:MM, or HH:MM:SS.",
 			},
 			{
 				type = "number",
-				name = "Length",
-				description = "The length of the smooth transition in seconds. Defaults to 1 second if not specified.",
+				name = "Duration",
+				description = "Transition duration to the new time of day. Defaults to instant.",
 				optional = true,
 			},
 		},
-		run = function(context, time, smooth, smoothLength)
-			-- Parse "time" as HH, HH:MM, or HH:MM:SS
-			local hours, minutes, seconds = 0, 0, 0
-			if time then
-				local parts = string.split(time, ":")
-				hours = tonumber(parts[1]) or 0
-				minutes = tonumber(parts[2]) or 0
-				seconds = tonumber(parts[3]) or 0
-			end
+		run = function(context, time: string, duration: number?)
+			local hours, minutes, seconds = unpack(string.split(time, ":"))
+			hours = math.clamp(tonumber(hours) or 0, 0, 23)
+			minutes = math.clamp(tonumber(minutes) or 0, 0, 59)
+			seconds = math.clamp(tonumber(seconds) or 0, 0, 59)
 
-			-- Clamp values to valid ranges
-			hours = math.clamp(hours, 0, 23)
-			minutes = math.clamp(minutes, 0, 59)
-			seconds = math.clamp(seconds, 0, 59)
-
-			-- Calculate total clock time in hours
 			local clockTime = hours + minutes / 60 + seconds / 3600
 
-			-- Format TimeOfDay as HH:MM:SS
-			local timeOfDay = string.format("%02d:%02d:%02d", hours, minutes, seconds)
-
-			if smooth then
-				local tween = context._K.Service.TweenService:Create(
-					Lighting,
-					TweenInfo.new(smoothLength or 1, Enum.EasingStyle.Linear, Enum.EasingDirection.InOut),
-					{ ClockTime = clockTime }
-				)
-				tween:Play()
-				tween.Completed:Wait()
+			if duration then
+				context._K.Service.TweenService
+					:Create(Lighting, TweenInfo.new(duration, Enum.EasingStyle.Linear), { ClockTime = clockTime })
+					:Play()
 			else
 				Lighting.ClockTime = clockTime
 			end
-			Lighting.TimeOfDay = timeOfDay
 		end,
 	},
 	{


### PR DESCRIPTION
Improves the `time` command, now it supports `HH:MM:SS`, `HH:MM` or just `HH`

Adds a new optional argument `smooth` and its companion `smoothLength`

`smooth` makes the time change smoothly via a Tween
`smoothLength` decides how long the Tween lasts for (lower number = quicker, higher number = slower)