### PR TITLE
feat: add usernames to ;link

### DIFF
--- a/src/DefaultCommands/General.luau
+++ b/src/DefaultCommands/General.luau
@@ -536,8 +536,8 @@ return {
 					billboard.Name = "_KLink"
 					billboard.LightInfluence = 0
 					billboard.AlwaysOnTop = true
-					billboard.Size = (player.DisplayName == player.Name) and UDim2.new(0, 250, 0, 35)
-						or UDim2.new(0, 250, 0, 50)
+					billboard.Size = (player.DisplayName == player.Name) and UDim2.fromOffset(250, 35)
+						or UDim2.fromOffset(250, 50)
 					billboard.SizeOffset = Vector2.new(0, 0.5)
 					billboard.StudsOffsetWorldSpace = Vector3.new(0, 5, 0)
 					local beam = Instance.new("Beam")
@@ -557,7 +557,7 @@ return {
 					label.Font = Enum.Font.RobotoMono
 					label.RichText = true
 					label.TextScaled = true
-					label.Size = UDim2.new(1, 0, 1, 0)
+					label.Size = UDim2.fromScale(1, 1)
 					label.Text = (player.DisplayName == player.Name) and `@{player.Name}`
 						or `{player.DisplayName}\n@{player.Name}`
 					label.Parent = billboard
@@ -605,16 +605,16 @@ return {
 				end
 			end
 
-		localPlayer.CharacterAdded:Connect(function()
-			for player in persist do
-				task.defer(link, player)
-			end
-		end)
+			localPlayer.CharacterAdded:Connect(function()
+				for player in persist do
+					task.defer(link, player)
+				end
+			end)
 
-		return {
-			persist = persist,
-			link = link,
-		}
+			return {
+				persist = persist,
+				link = link,
+			}
 		end,
 
 		runClient = function(context, players, persistent)


### PR DESCRIPTION
- adds Display Name, Username, & Distance above target's head when using ;link
- colors link based on target's team color

<img width="413" height="393" alt="image" src="https://github.com/user-attachments/assets/c8cf9672-8064-4331-a64e-b205f85a86d9" />
