### PR TITLE
Added a FAQ Hyperlink Bullet Point

### DIFF
--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -8,7 +8,7 @@ sidebar_position: 5
 Kohl's Admin is currently in development. Everything in these docs is subject to change.
 :::
 
-If you need help with Kohl's Admin (KA), there are several ways to get assistance. The Kohl's Admin community is active and ready to support you as you integrate and use the tool in your Roblox game.
+If you need help with Kohl's Admin (KA), there are several ways to get assistance. The Kohl's Admin community is active and ready to support you as you integrate and use the tool in your Roblox experience(s).
 
 ## Community Support
 
@@ -29,6 +29,7 @@ Before reaching out for help, make sure to review the documentation. Many common
 
 - **[Getting Started](/docs/getting-started/installation)**: A step-by-step guide to installing and configuring Kohl's Admin.
 <!-- - **[Troubleshooting](/docs/troubleshooting)**: Solutions to common problems you might encounter. -->
+- **[FAQ Posts](https://discord.com/channels/694630328064671775/1298904707498246144)**: Posts written by the support team regarding frequently asked questions from the community.
 
 ## Contact Us
 


### PR DESCRIPTION
In the support section it says in a certain spot that if you need help go to the following sections and only shows 1 bullet point being a guide. I decided it'd also be nice to link to the FAQ.